### PR TITLE
Convert Log from class to a function

### DIFF
--- a/src/S.ts
+++ b/src/S.ts
@@ -312,11 +312,20 @@ class ComputationNode {
     }
 }
 
-class Log {
-    node1 = null as null | ComputationNode;
-    node1slot = 0;
-    nodes = null as null | ComputationNode[];
-    nodeslots = null as null | number[];
+interface Log {
+  node1     : ComputationNode | null;
+  node1slot : number;
+  nodes     : ComputationNode[] | null;
+  nodeslots : number[] | null;
+}
+
+function Log() : Log {
+    return {
+        node1: null,
+        node1slot: 0,
+        nodes: null,
+        nodeslots: null
+    }
 }
     
 class Queue<T> {
@@ -488,12 +497,12 @@ function logRead(from : Log) {
 }
 
 function logDataRead(data : DataNode) {
-    if (data.log === null) data.log = new Log();
+    if (data.log === null) data.log = Log();
     logRead(data.log);
 }
 
 function logComputationRead(node : ComputationNode) {
-    if (node.log === null) node.log = new Log();
+    if (node.log === null) node.log = Log();
     logRead(node.log);
 }
 


### PR DESCRIPTION
This PR rewrites `Log` as a simple function that returns a plain object. This change slightly improves the final bundle size by removing an iife.

Bundled output before this PR:

```js
var Log = /** @class */ (function () {
  function Log() {
    this.node1 = null;
    this.node1slot = 0;
    this.nodes = null;
    this.nodeslots = null;
  }
  return Log;
}());
```

After this PR:

```js
function Log() {
  return {
    node1: null,
    node1slot: 0,
    nodes: null,
    nodeslots: null
  };
}
```