### PR TITLE
Better type signature for S.root

### DIFF
--- a/dist/es/S.d.ts
+++ b/dist/es/S.d.ts
@@ -1,5 +1,6 @@
 export interface S {
-    root<T>(fn: (dispose?: () => void) => T): T;
+    root<T>(fn: (dispose: () => void) => T): T;
+    root<T>(fn: () => T): T;
     <T>(fn: () => T): () => T;
     <T>(fn: (v: T) => T, seed: T): () => T;
     on<T>(ev: () => any, fn: () => T): () => T;

--- a/dist/es/withsubclocks.d.ts
+++ b/dist/es/withsubclocks.d.ts
@@ -1,5 +1,6 @@
 export interface S {
     root<T>(fn: (dispose: () => void) => T): T;
+    root<T>(fn: () => T): T;
     <T>(fn: () => T): () => T;
     <T>(fn: (v: T) => T, seed: T): () => T;
     on<T>(ev: () => any, fn: () => T): () => T;

--- a/src/S.ts
+++ b/src/S.ts
@@ -1,6 +1,7 @@
 export interface S {
     // Computation root
-    root<T>(fn : (dispose? : () => void) => T) : T;
+    root<T>(fn : (dispose : () => void) => T) : T;
+    root<T>(fn : () => T) : T;
 
     // Computation constructors
     <T>(fn : () => T) : () => T;

--- a/src/withsubclocks.ts
+++ b/src/withsubclocks.ts
@@ -2,6 +2,7 @@
 export interface S {
     // Computation root
     root<T>(fn : (dispose : () => void) => T) : T;
+    root<T>(fn : () => T) : T;
 
     // Computation constructors
     <T>(fn : () => T) : () => T;


### PR DESCRIPTION
With the type defined like this, when `dispose` is provided, TS know it isn't null.